### PR TITLE
Bugfix endpoints wishlists

### DIFF
--- a/backend/app/api/routes/wishlists.py
+++ b/backend/app/api/routes/wishlists.py
@@ -228,12 +228,6 @@ def delete_wishlist(
             detail="The wishlist does not belong to the current user",
         )
 
-    # Eliminar todos los enlaces de libros asociados a la wishlist
-    statement = select(WishlistBookLink).where(WishlistBookLink.wishlist_id == wishlist_id)
-    links = session.exec(statement).all()
-    for link in links:
-        session.delete(link)
-
     session.delete(db_wishlist)
     session.commit()
     return Message(message="Wishlist deleted successfully")


### PR DESCRIPTION
Se ha arreglado que en el endpoint delete /{wishlist_id}, los usuarios no puedan borrar wishlists de otros usuarios, es decir, se comprueba que la wishlist pertenezca al account actual.